### PR TITLE
fix: baseOptions Documentation Url

### DIFF
--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -14,7 +14,7 @@ export const baseOptions: BaseLayoutProps = {
   links: [
     {
       text: 'Documentation',
-      url: '/docs',
+      url: '/docs/rumusan',
       active: 'nested-url',
     },
   ],


### PR DESCRIPTION
Updates the url of `Documentation` from `/docs` to `/docs/rumusan`